### PR TITLE
Fix topic name

### DIFF
--- a/priv/bunny.html
+++ b/priv/bunny.html
@@ -134,9 +134,10 @@ client.onMessageArrived = function (message) {
 
 var options = {
     timeout: 3,
+    keepAliveInterval: 30,
     onSuccess: function () {
         debug("CONNECTION SUCCESS");
-        client.subscribe('/topic/bunny', {qos: 1});
+        client.subscribe("bunny", {qos: 1});
     },
     onFailure: function (message) {
         debug("CONNECTION FAILURE - " + message.errorMessage);
@@ -159,7 +160,7 @@ $('#first input').focus(function() {
 
 send = function(data) {
   message = new Paho.MQTT.Message(data);
-  message.destinationName = "/topic/bunny";
+  message.destinationName = "bunny";
   debug("SEND ON " + message.destinationName + " PAYLOAD " + data);
   client.send(message);
 };

--- a/priv/echo.html
+++ b/priv/echo.html
@@ -83,7 +83,7 @@
 
         var print_first = pipe('#first', function(data) {
             message = new Paho.MQTT.Message(data);
-            message.destinationName = "/topic/test";
+            message.destinationName = "test";
             debug("SEND ON " + message.destinationName + " PAYLOAD " + data);
             client.send(message);
         });
@@ -107,9 +107,10 @@
 
         var options = {
             timeout: 3,
+            keepAliveInterval: 30,
             onSuccess: function () {
                 debug("CONNECTION SUCCESS");
-                client.subscribe('/topic/test', {qos: 1});
+                client.subscribe("test", {qos: 1});
             },
             onFailure: function (message) {
                 debug("CONNECTION FAILURE - " + message.errorMessage);


### PR DESCRIPTION
- Topic names do not need "/topic/" prefix
- Normalizing the name also makes this example work with the STOMP example
- Also added `keepAliveInterval` to keep WebSocket connection from dropping